### PR TITLE
Update dev dependencies and test against all Angular versions

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,0 @@
-{
-  "directory": "bower"
-}

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 *.iml
 
 node_modules/
-bower/
+bower_components/
 npm-debug.log

--- a/.jshintrc
+++ b/.jshintrc
@@ -53,9 +53,10 @@
 
   "browser": true,
   "node": true,
+  "jasmine": true,
 
   "globals": {
     "angular": false,
-    "$": false
+    "inject": false
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
 node_js:
-  - "0.12.7"
+  - "8"
 before_install:
   - "npm install -g grunt-cli"
-  - "npm install -g bower"
 install:
   - "npm install"
-  - "bower install"
 before_script:
   - "grunt build"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,19 +1,28 @@
+var niv = require('npm-install-version');
+
 /*global module:false*/
 module.exports = function (grunt) {
 
   require('jit-grunt')(grunt);
 
+  var pkg = require('./package.json');
+
   grunt.initConfig({
-    pkg: grunt.file.readJSON('package.json'),
+    pkg: pkg,
     banner: '/*! <%= pkg.name %> - v<%= pkg.version %> - ' +
     '<%= grunt.template.today("yyyy-mm-dd") %> */\n',
-    clean: ['dist'],
-    jshint: {
-      all: ['src/**/*.js', 'test/**/*.js'],
-      gruntfile: {
-        src: 'Gruntfile.js'
-      }
+
+    clean: {
+      dist: ['dist']
     },
+
+    jshint: {
+      options: {
+        jshintrc: '.jshintrc'
+      },
+      all: ['src/**/*.js', 'test/**/*.js', 'Gruntfile.js']
+    },
+
     concat: {
       options: {
         banner: '<%= banner %>',
@@ -24,6 +33,7 @@ module.exports = function (grunt) {
         dest: 'dist/<%= pkg.name %>.js'
       }
     },
+
     uglify: {
       options: {
         banner: '<%= banner %>'
@@ -33,14 +43,36 @@ module.exports = function (grunt) {
         dest: 'dist/<%= pkg.name %>.min.js'
       }
     },
-    karma: {
-      unit: {
-        configFile: 'karma.conf.js'
-      }
-    }
+
+    // Build multiple karma instances for each Angular versions
+    karma: (function() {
+      var configs = {};
+
+      pkg.angularVersions.forEach(function(version) {
+        configs[version] = {
+          configFile: 'karma.conf.js',
+          client: {
+            args: {
+              version: version
+            }
+          }
+        };
+      });
+
+      return configs;
+    }())
   });
 
-  grunt.registerTask('test', ['karma']);
+  grunt.registerTask('install-angular', function() {
+    grunt.log.ok('Install Angular ' + pkg.angularVersions);
+
+    pkg.angularVersions.forEach(function(version) {
+      niv.install('angular@' + version, {quiet: true});
+      niv.install('angular-mocks@' + version, {quiet: true});
+    });
+  });
+
+  grunt.registerTask('test', ['install-angular', 'karma']);
 
   grunt.registerTask('build', ['clean', 'jshint', 'concat', 'uglify']);
 };

--- a/bower.json
+++ b/bower.json
@@ -17,8 +17,5 @@
   ],
   "dependencies": {
     "angular": ">=1.2"
-  },
-  "devDependencies": {
-    "angular-mocks": ">=1.2"
   }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,13 +1,12 @@
 module.exports = function (config) {
-
   config.set({
     frameworks: [
       'jasmine',
       'jasmine-matchers'
     ],
     files: [
-      'bower/angular/angular.js',
-      'bower/angular-mocks/angular-mocks.js',
+      'node_modules/angular@' + config.client.args.version + '/angular.js',
+      'node_modules/angular-mocks@' + config.client.args.version + '/angular-mocks.js',
       'src/**/*.js',
       'test/**/*.test.js'
     ],

--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-uglify": "^2.0.0",
+    "grunt-contrib-uglify": "^3.0.0",
     "grunt-karma": "^2.0.0",
-    "jasmine-core": "^2.4.1",
+    "jasmine-core": "^3.2.1",
     "jit-grunt": "^0.10.0",
-    "karma": "^1.1.2",
-    "karma-jasmine": "^1.0.2",
-    "karma-jasmine-matchers": "^2.0.2",
-    "karma-phantomjs-launcher": "^1.0.1",
-    "phantomjs": "^2.1.7"
-  }
+    "karma": "^3.0.0",
+    "karma-jasmine": "^1.1.2",
+    "karma-jasmine-matchers": "^3.8.3",
+    "karma-phantomjs-launcher": "^1.0.4",
+    "npm-install-version": "^6.0.2"
+  },
+  "angularVersions": ["1.2", "1.3", "1.4", "1.5", "1.6", "1.7"]
 }

--- a/src/angular-q-extras.js
+++ b/src/angular-q-extras.js
@@ -1,4 +1,4 @@
-(function () {
+(function (angular) {
   'use strict';
 
   angular.module('angular-q-extras', [])
@@ -117,4 +117,4 @@
 
   }
 
-})();
+})(window.angular);


### PR DESCRIPTION
I add some free time this evening so here it is.

- Bumps all versions of dev dependencies
- Removes Bower from the build process (the lib itself is still compatible with Bower)
- Runs the tests against all versions of AngularJS from 1.2 to 1.7